### PR TITLE
Refactor RTreeIndex tests and remove unused configurations

### DIFF
--- a/internal/util/indexparamcheck/rtree_checker_test.go
+++ b/internal/util/indexparamcheck/rtree_checker_test.go
@@ -17,8 +17,6 @@
 package indexparamcheck
 
 import (
-	"fmt"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -43,114 +41,6 @@ func TestRTREEChecker(t *testing.T) {
 		}
 		err := c.CheckValidDataType(IndexRTREE, field)
 		assert.Error(t, err)
-	})
-
-	t.Run("valid parameters with defaults", func(t *testing.T) {
-		params := make(map[string]string)
-		err := c.CheckTrain(schemapb.DataType_Geometry, params)
-		assert.NoError(t, err)
-
-		// Check that defaults are applied
-		assert.Equal(t, fmt.Sprintf("%f", DefaultRTreeFillFactor), params[RTreeFillFactor])
-		assert.Equal(t, strconv.Itoa(DefaultRTreeIndexCapacity), params[RTreeIndexCapacity])
-		assert.Equal(t, strconv.Itoa(DefaultRTreeLeafCapacity), params[RTreeLeafCapacity])
-		assert.Equal(t, strconv.Itoa(DefaultRTreeDim), params[RTreeDim])
-		assert.Equal(t, DefaultRTreeRV, params[RTreeRV])
-	})
-
-	t.Run("valid custom parameters", func(t *testing.T) {
-		params := map[string]string{
-			RTreeFillFactor:    "0.7",
-			RTreeIndexCapacity: "150",
-			RTreeLeafCapacity:  "150",
-			RTreeDim:           "2",
-			RTreeRV:            "RV_LINEAR",
-		}
-		err := c.CheckTrain(schemapb.DataType_Geometry, params)
-		assert.NoError(t, err)
-	})
-
-	t.Run("invalid fillFactor - too low", func(t *testing.T) {
-		params := map[string]string{
-			RTreeFillFactor: "0.05",
-		}
-		err := c.CheckTrain(schemapb.DataType_Geometry, params)
-		assert.Error(t, err)
-	})
-
-	t.Run("invalid fillFactor - too high", func(t *testing.T) {
-		params := map[string]string{
-			RTreeFillFactor: "1.5",
-		}
-		err := c.CheckTrain(schemapb.DataType_Geometry, params)
-		assert.Error(t, err)
-	})
-
-	t.Run("invalid indexCapacity - too low", func(t *testing.T) {
-		params := map[string]string{
-			RTreeIndexCapacity: "1",
-		}
-		err := c.CheckTrain(schemapb.DataType_Geometry, params)
-		assert.Error(t, err)
-	})
-
-	t.Run("invalid indexCapacity - too high", func(t *testing.T) {
-		params := map[string]string{
-			RTreeIndexCapacity: "1500",
-		}
-		err := c.CheckTrain(schemapb.DataType_Geometry, params)
-		assert.Error(t, err)
-	})
-
-	t.Run("invalid leafCapacity - too low", func(t *testing.T) {
-		params := map[string]string{
-			RTreeLeafCapacity: "1",
-		}
-		err := c.CheckTrain(schemapb.DataType_Geometry, params)
-		assert.Error(t, err)
-	})
-
-	t.Run("invalid leafCapacity - too high", func(t *testing.T) {
-		params := map[string]string{
-			RTreeLeafCapacity: "1500",
-		}
-		err := c.CheckTrain(schemapb.DataType_Geometry, params)
-		assert.Error(t, err)
-	})
-
-	t.Run("invalid dimension - too low", func(t *testing.T) {
-		params := map[string]string{
-			RTreeDim: "1",
-		}
-		err := c.CheckTrain(schemapb.DataType_Geometry, params)
-		assert.Error(t, err)
-	})
-
-	t.Run("invalid dimension - too high", func(t *testing.T) {
-		params := map[string]string{
-			RTreeDim: "4",
-		}
-		err := c.CheckTrain(schemapb.DataType_Geometry, params)
-		assert.Error(t, err)
-	})
-
-	t.Run("invalid rv value", func(t *testing.T) {
-		params := map[string]string{
-			RTreeRV: "INVALID_RV",
-		}
-		err := c.CheckTrain(schemapb.DataType_Geometry, params)
-		assert.Error(t, err)
-	})
-
-	t.Run("valid rv values", func(t *testing.T) {
-		validRVs := []string{"RV_LINEAR", "RV_QUADRATIC", "RV_RSTAR"}
-		for _, rv := range validRVs {
-			params := map[string]string{
-				RTreeRV: rv,
-			}
-			err := c.CheckTrain(schemapb.DataType_Geometry, params)
-			assert.NoError(t, err)
-		}
 	})
 
 	t.Run("non-geometry data type", func(t *testing.T) {


### PR DESCRIPTION
- Removed unused parameters from RTreeIndex test cases, including fillFactor, indexCapacity, leafCapacity, and rv.
- Updated file extensions in test cases from .idx and .dat to .bgi to reflect changes in the index file format.