### PR TITLE
enhance:change go sdk to use GeometryWktArray

### DIFF
--- a/client/column/columns.go
+++ b/client/column/columns.go
@@ -210,7 +210,7 @@ func FieldDataColumn(fd *schemapb.FieldData, begin, end int) (Column, error) {
 		return parseScalarData(fd.GetFieldName(), fd.GetScalars().GetJsonData().GetData(), begin, end, validData, NewColumnJSONBytes, NewNullableColumnJSONBytes)
 
 	case schemapb.DataType_Geometry:
-		return parseScalarData(fd.GetFieldName(), fd.GetScalars().GetGeometryData().GetData(), begin, end, validData, NewColumnGeometryBytes, NewNullableColumnGeometry)
+		return parseScalarData(fd.GetFieldName(), fd.GetScalars().GetGeometryWktData().GetData(), begin, end, validData, NewColumnGeometryWKT, NewNullableColumnGeometryWKT)
 
 	case schemapb.DataType_FloatVector:
 		vectors := fd.GetVectors()

--- a/client/column/conversion.go
+++ b/client/column/conversion.go
@@ -117,7 +117,8 @@ func values2FieldData[T any](values []T, fieldType entity.FieldType, dim int) *s
 		entity.FieldTypeInt64,
 		entity.FieldTypeVarChar,
 		entity.FieldTypeString,
-		entity.FieldTypeJSON:
+		entity.FieldTypeJSON,
+		entity.FieldTypeGeometry:
 		fd.Field = &schemapb.FieldData_Scalars{
 			Scalars: values2Scalars(values, fieldType), // scalars,
 		}
@@ -197,6 +198,12 @@ func values2Scalars[T any](values []T, fieldType entity.FieldType) *schemapb.Sca
 			JsonData: &schemapb.JSONArray{
 				Data: data,
 			},
+		}
+	case entity.FieldTypeGeometry:
+		var strVals []string
+		strVals, ok = any(values).([]string)
+		scalars.Data = &schemapb.ScalarField_GeometryWktData{
+			GeometryWktData: &schemapb.GeometryWktArray{Data: strVals},
 		}
 	}
 	// shall not be accessed

--- a/client/column/geometry_test.go
+++ b/client/column/geometry_test.go
@@ -11,20 +11,20 @@ import (
 	"github.com/milvus-io/milvus/client/v2/entity"
 )
 
-type ColumnGeometryBytesSuite struct {
+type ColumnGeometryWKTSuite struct {
 	suite.Suite
 }
 
-func (s *ColumnGeometryBytesSuite) SetupSuite() {
+func (s *ColumnGeometryWKTSuite) SetupSuite() {
 	rand.Seed(time.Now().UnixNano())
 }
 
-func (s *ColumnGeometryBytesSuite) TestAttrMethods() {
-	columnName := fmt.Sprintf("column_Geometrybs_%d", rand.Int())
+func (s *ColumnGeometryWKTSuite) TestAttrMethods() {
+	columnName := fmt.Sprintf("column_Geometrywkt_%d", rand.Int())
 	columnLen := 8 + rand.Intn(10)
 
-	v := make([][]byte, columnLen)
-	column := NewColumnGeometryBytes(columnName, v)
+	v := make([]string, columnLen)
+	column := NewColumnGeometryWKT(columnName, v)
 
 	s.Run("test_meta", func() {
 		ft := entity.FieldTypeGeometry
@@ -61,22 +61,16 @@ func (s *ColumnGeometryBytesSuite) TestAttrMethods() {
 	})
 
 	s.Run("test_append_value", func() {
-		item := make([]byte, 10)
+		item := "POINT (30.123 -10.456)"
 		err := column.AppendValue(item)
 		s.NoError(err)
 		s.Equal(columnLen+1, column.Len())
 		val, err := column.ValueByIdx(columnLen)
 		s.NoError(err)
 		s.Equal(item, val)
-
-		err = column.AppendValue("POINT (30.123 -10.456)")
-		s.NoError(err)
-
-		err = column.AppendValue(1)
-		s.Error(err)
 	})
 }
 
-func TestColumnGeometryBytes(t *testing.T) {
-	suite.Run(t, new(ColumnGeometryBytesSuite))
+func TestColumnGeometryWKT(t *testing.T) {
+	suite.Run(t, new(ColumnGeometryWKTSuite))
 }

--- a/client/column/nullable.go
+++ b/client/column/nullable.go
@@ -18,17 +18,17 @@ package column
 
 var (
 	// scalars
-	NewNullableColumnBool      NullableColumnCreateFunc[bool, *ColumnBool]        = NewNullableColumnCreator(NewColumnBool).New
-	NewNullableColumnInt8      NullableColumnCreateFunc[int8, *ColumnInt8]        = NewNullableColumnCreator(NewColumnInt8).New
-	NewNullableColumnInt16     NullableColumnCreateFunc[int16, *ColumnInt16]      = NewNullableColumnCreator(NewColumnInt16).New
-	NewNullableColumnInt32     NullableColumnCreateFunc[int32, *ColumnInt32]      = NewNullableColumnCreator(NewColumnInt32).New
-	NewNullableColumnInt64     NullableColumnCreateFunc[int64, *ColumnInt64]      = NewNullableColumnCreator(NewColumnInt64).New
-	NewNullableColumnVarChar   NullableColumnCreateFunc[string, *ColumnVarChar]   = NewNullableColumnCreator(NewColumnVarChar).New
-	NewNullableColumnString    NullableColumnCreateFunc[string, *ColumnString]    = NewNullableColumnCreator(NewColumnString).New
-	NewNullableColumnFloat     NullableColumnCreateFunc[float32, *ColumnFloat]    = NewNullableColumnCreator(NewColumnFloat).New
-	NewNullableColumnDouble    NullableColumnCreateFunc[float64, *ColumnDouble]   = NewNullableColumnCreator(NewColumnDouble).New
-	NewNullableColumnJSONBytes NullableColumnCreateFunc[[]byte, *ColumnJSONBytes] = NewNullableColumnCreator(NewColumnJSONBytes).New
-	NewNullableColumnGeometry   NullableColumnCreateFunc[[]byte, *ColumnGeometryBytes] = NewNullableColumnCreator(NewColumnGeometryBytes).New
+	NewNullableColumnBool        NullableColumnCreateFunc[bool, *ColumnBool]          = NewNullableColumnCreator(NewColumnBool).New
+	NewNullableColumnInt8        NullableColumnCreateFunc[int8, *ColumnInt8]          = NewNullableColumnCreator(NewColumnInt8).New
+	NewNullableColumnInt16       NullableColumnCreateFunc[int16, *ColumnInt16]        = NewNullableColumnCreator(NewColumnInt16).New
+	NewNullableColumnInt32       NullableColumnCreateFunc[int32, *ColumnInt32]        = NewNullableColumnCreator(NewColumnInt32).New
+	NewNullableColumnInt64       NullableColumnCreateFunc[int64, *ColumnInt64]        = NewNullableColumnCreator(NewColumnInt64).New
+	NewNullableColumnVarChar     NullableColumnCreateFunc[string, *ColumnVarChar]     = NewNullableColumnCreator(NewColumnVarChar).New
+	NewNullableColumnString      NullableColumnCreateFunc[string, *ColumnString]      = NewNullableColumnCreator(NewColumnString).New
+	NewNullableColumnFloat       NullableColumnCreateFunc[float32, *ColumnFloat]      = NewNullableColumnCreator(NewColumnFloat).New
+	NewNullableColumnDouble      NullableColumnCreateFunc[float64, *ColumnDouble]     = NewNullableColumnCreator(NewColumnDouble).New
+	NewNullableColumnJSONBytes   NullableColumnCreateFunc[[]byte, *ColumnJSONBytes]   = NewNullableColumnCreator(NewColumnJSONBytes).New
+	NewNullableColumnGeometryWKT NullableColumnCreateFunc[string, *ColumnGeometryWKT] = NewNullableColumnCreator(NewColumnGeometryWKT).New
 	// array
 	NewNullableColumnBoolArray    NullableColumnCreateFunc[[]bool, *ColumnBoolArray]      = NewNullableColumnCreator(NewColumnBoolArray).New
 	NewNullableColumnInt8Array    NullableColumnCreateFunc[[]int8, *ColumnInt8Array]      = NewNullableColumnCreator(NewColumnInt8Array).New

--- a/client/milvusclient/client_suite_test.go
+++ b/client/milvusclient/client_suite_test.go
@@ -212,14 +212,14 @@ func (s *MockSuiteBase) getJSONBytesFieldData(name string, data [][]byte, isDyna
 	}
 }
 
-func (s *MockSuiteBase) getGeometryBytesFieldData(name string, data [][]byte) *schemapb.FieldData {
+func (s *MockSuiteBase) getGeometryWktFieldData(name string, data []string) *schemapb.FieldData {
 	return &schemapb.FieldData{
 		Type:      schemapb.DataType_Geometry,
 		FieldName: name,
 		Field: &schemapb.FieldData_Scalars{
 			Scalars: &schemapb.ScalarField{
-				Data: &schemapb.ScalarField_GeometryData{
-					GeometryData: &schemapb.GeometryArray{
+				Data: &schemapb.ScalarField_GeometryWktData{
+					GeometryWktData: &schemapb.GeometryWktArray{
 						Data: data,
 					},
 				},

--- a/tests/go_client/go.mod
+++ b/tests/go_client/go.mod
@@ -5,10 +5,12 @@ go 1.24.4
 require (
 	github.com/milvus-io/milvus/client/v2 v2.5.4
 	github.com/milvus-io/milvus/pkg/v2 v2.5.7
+
+	github.com/peterstace/simplefeatures v0.54.0
 	github.com/quasilyte/go-ruleguard/dsl v0.3.22
 	github.com/samber/lo v1.27.0
 	github.com/stretchr/testify v1.10.0
-	// github.com/twpayne/go-geom v1.6.1
+	github.com/twpayne/go-geom v1.5.2
 	github.com/x448/float16 v0.8.4
 	go.uber.org/zap v1.27.0
 	google.golang.org/grpc v1.65.0

--- a/tests/go_client/go.sum
+++ b/tests/go_client/go.sum
@@ -357,6 +357,8 @@ github.com/panjf2000/ants/v2 v2.11.3 h1:AfI0ngBoXJmYOpDh9m516vjqoUu2sLrIVgppI9TZ
 github.com/panjf2000/ants/v2 v2.11.3/go.mod h1:8u92CYMUc6gyvTIw8Ru7Mt7+/ESnJahz5EVtqfrilek=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/peterstace/simplefeatures v0.54.0 h1:n7KEa6JYt9t+Eq5z9+93TPr3yavW1kJPiuNwwxX6gVs=
+github.com/peterstace/simplefeatures v0.54.0/go.mod h1:T7VKWq4zT2YeFYlwLRwJnhuYV2rxxDGG3G1XkNHAJLU=
 github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c h1:xpW9bvK+HuuTmyFqUwr+jcCvpVkK7sumiz+ko5H9eq4=
 github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c/go.mod h1:X2r9ueLEUZgtx2cIogM0v4Zj5uvvzhuuiu7Pn8HzMPg=
@@ -487,6 +489,8 @@ github.com/tklauser/numcpus v0.7.0/go.mod h1:bb6dMVcj8A42tSE7i32fsIUCbQNllK5iDgu
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 h1:uruHq4dN7GR16kFc5fp3d1RIYzJW5onx8Ybykw2YQFA=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
+github.com/twpayne/go-geom v1.5.2 h1:LyRfBX2W0LM7XN/bGqX0XxrJ7SZc3XwmxU4aj4kSoxw=
+github.com/twpayne/go-geom v1.5.2/go.mod h1:3z6O2sAnGtGCXx4Q+5nPOLCA5e8WI2t3cthdb1P2HH8=
 github.com/uber/jaeger-client-go v2.30.0+incompatible h1:D6wyKGCecFaSRUpo8lCVbaOOb6ThwMmTEbhRwtKR97o=
 github.com/uber/jaeger-client-go v2.30.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=

--- a/tests/go_client/testcases/helper/data_helper.go
+++ b/tests/go_client/testcases/helper/data_helper.go
@@ -292,7 +292,7 @@ func GenNestedJSONExprKey(depth int, jsonField string) string {
 	return fmt.Sprintf("%s['%s']", jsonField, strings.Join(pathParts, "']['"))
 }
 
-func GenDefaultGeometryData(nb int, option GenDataOption) [][]byte {
+func GenDefaultGeometryData(nb int, option GenDataOption) []string {
 	const (
 		point           = "POINT (30.123 -10.456)"
 		linestring      = "LINESTRING (30.123 -10.456, 10.789 30.123, -40.567 40.890)"
@@ -302,10 +302,10 @@ func GenDefaultGeometryData(nb int, option GenDataOption) [][]byte {
 		multipolygon    = "MULTIPOLYGON (((30.123 -10.456, 40.678 40.890, 20.345 40.567, 10.123 20.456, 30.123 -10.456)),((15.123 5.456, 25.678 5.890, 25.345 15.567, 15.123 15.456, 15.123 5.456)))"
 	)
 	wktArray := [6]string{point, linestring, polygon, multipoint, multilinestring, multipolygon}
-	geometryValues := make([][]byte, 0, nb)
+	geometryValues := make([]string, 0, nb)
 	start := option.start
 	for i := start; i < start+nb; i++ {
-		geometryValues = append(geometryValues, []byte(wktArray[i%6]))
+		geometryValues = append(geometryValues, wktArray[i%6])
 	}
 	return geometryValues
 }
@@ -412,7 +412,7 @@ func GenColumnData(nb int, fieldType entity.FieldType, option GenDataOption) col
 
 	case entity.FieldTypeGeometry:
 		geometryValues := GenDefaultGeometryData(nb, option)
-		return column.NewColumnGeometryBytes(fieldName, geometryValues)
+		return column.NewColumnGeometryWKT(fieldName, geometryValues)
 
 	case entity.FieldTypeFloatVector:
 		vecFloatValues := make([][]float32, 0, nb)


### PR DESCRIPTION
- Renamed geometry column types from `ColumnGeometryBytes` to `ColumnGeometryWKT` to reflect the use of Well-Known Text (WKT) format.
- Updated related functions and tests to accommodate the new geometry representation.
- Enhanced helper functions and test cases to support string-based geometry data.
- Added a new nullable column creator for `ColumnGeometryWKT`.